### PR TITLE
Remove the boost version.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - toolchain
     - pcre          # [unix]
     - python        # [unix]
-    - boost 1.61.*  # [unix]
+    - boost         # [unix]
   run:
     - pcre          # [unix]
-    - boost 1.61.*  # [unix]
+    - boost         # [unix]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 68a202ebfc62647495074a190a115b629e84c56d74d3017ccb43e56a4b9b83f6  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true                             # [not py27]
   detect_binary_files_with_prefix: true  # [unix]
 


### PR DESCRIPTION
Closes https://github.com/conda-forge/swig-feedstock/issues/2

Remove the specific version with the boost dependency. See #2.

	modified:   recipe/meta.yaml