### PR TITLE
Do not depend on boost

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 21ce6cbe297a56b697ef6e7e92a83e75ca41dedc87e48282ab444591986c35f5  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not py27]
   detect_binary_files_with_prefix: true  # [unix]
 
@@ -22,10 +22,8 @@ requirements:
     - toolchain
     - pcre  # [unix]
     - python  # [unix]
-    - boost-cpp 1.64.*  # [unix]
   run:
     - pcre  # [unix]
-    - boost-cpp 1.64.*  # [unix]
 
 test:
   commands:


### PR DESCRIPTION
When grepping boost in Sources or Lib I cannot see where swig should depend on boost. What may have lead to that conclusion is that swig detects boost to enable additional tests. But as far as we're concerned it doesn't change nor the swig binary nor the provided .i files.
